### PR TITLE
Per agent goal state

### DIFF
--- a/src/GamygdalaNet.Test/GamygdalaNet.Test.csproj
+++ b/src/GamygdalaNet.Test/GamygdalaNet.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/GamygdalaNet.Test/GamygdalaShould.cs
+++ b/src/GamygdalaNet.Test/GamygdalaShould.cs
@@ -158,7 +158,7 @@ namespace GamygdalaNet.Test
 
             var npcAgent = new Agent("npc");
             var dieGoal = new Goal("die", -1);
-            var winGoal = new Goal("win", 1) {Likelihood = 0.1875};
+            var winGoal = new Goal("win", 1);
             const double health = 0.3; // Health as percentage of max hit points.
             const double dyingLikelihood = 1.0 - health;
             var woundedBelief = new Belief(dyingLikelihood, npcAgent.Name, new[] {dieGoal.Name},
@@ -171,6 +171,7 @@ namespace GamygdalaNet.Test
             _gamygdala.RegisterGoal(winGoal);
             npcAgent.AddGoal(dieGoal);
             npcAgent.AddGoal(winGoal);
+            npcAgent.SetGoalLikelihood(winGoal.Name, 0.1875);
             _gamygdala.Appraise(woundedBelief);
             var initialEmotions = npcAgent.GetEmotionalState();
             initialEmotions.Length.Should().Be(1);

--- a/src/GamygdalaNet/Agents/Agent.cs
+++ b/src/GamygdalaNet/Agents/Agent.cs
@@ -224,36 +224,57 @@ namespace GamygdalaNet.Agents
         }
 
         /// <summary>
-        ///     This function returns a summation-based Pleasure Arousal Dominance mapping of the emotional state as is
-        ///     (gain=false), or a PAD mapping based on a gained limiter (limited between 0 and 1), of which the gain can be set by
-        ///     using <see cref="SetGain" />. It sums over all emotions the equivalent PAD values of each emotion (i.e.,
-        ///     [P,A,D]=SUM(Emotion_i([P,A,D]))), which is then gained or not. A high gain factor works well when appraisals are
-        ///     small and rare, and you want to see the effect of these appraisals. A low gain factor (close to 0 but in any case
-        ///     below 1) works well for high frequency and/or large appraisals, so that the effect of these is dampened.
+        ///     Computes the Pleasure-Arousal-Dominance mapping of the
+        ///     agent's emotional state via Reilly's logarithmic
+        ///     aggregator (equation 5 from Popescu, Broekens, van
+        ///     Someren, "GAMYGDALA: An Emotion Engine for Games"):
+        ///     <code>PAD ← 0.1 × log₂(Σ_e 2^(10 × PAD(e) × intensity(e)))</code>
+        ///     Linear for small values and less additive as values
+        ///     grow, "at least as intense as the most intense
+        ///     component" without strict summation. The paper picks
+        ///     this over sigmoid normalization specifically because
+        ///     sigmoid distorts small values. A defensive clamp to
+        ///     <c>[-1, +1]</c> protects against the rare case of
+        ///     multiple high-intensity same-polarity emotions
+        ///     stacking past the natural range (log-sum-exp can
+        ///     mildly exceed max contributor by up to log₂(N)/10).
+        ///     The optional <paramref name="useGain" /> applies the
+        ///     classical Gamygdala gain compression on top, useful
+        ///     when the consumer wants additional dampening for
+        ///     high-frequency appraisal scenarios.
         /// </summary>
-        /// <param name="useGain">Whether to use the gain function or not.</param>
+        /// <param name="useGain">Whether to apply the optional gain function on top of the log-sum-exp aggregation.</param>
         /// <returns>The calculated PAD state.</returns>
         public PadState GetPadState(bool useGain = false)
         {
-            var pleasure = 0.0;
-            var arousal = 0.0;
-            var dominance = 0.0;
+            if (_internalState.Count == 0) return new PadState(0.0, 0.0, 0.0);
 
+            var sumPleasure = 0.0;
+            var sumArousal = 0.0;
+            var sumDominance = 0.0;
             foreach (var emotion in _internalState)
             {
-                pleasure += emotion.Value.Intensity * MapPad[emotion.Key].Pleasure;
-                arousal += emotion.Value.Intensity * MapPad[emotion.Key].Arousal;
-                dominance += emotion.Value.Intensity * MapPad[emotion.Key].Dominance;
+                var intensity = emotion.Value.Intensity.Value;
+                var pad = MapPad[emotion.Key];
+                sumPleasure += System.Math.Pow(2.0, 10.0 * pad.Pleasure * intensity);
+                sumArousal += System.Math.Pow(2.0, 10.0 * pad.Arousal * intensity);
+                sumDominance += System.Math.Pow(2.0, 10.0 * pad.Dominance * intensity);
             }
+
+            // Equation 5 outer transform. Empty pool guarded above so
+            // the log argument is always positive. Math.Log(x, 2.0)
+            // is the netstandard2.0-compatible spelling of log2.
+            var pleasure = 0.1 * System.Math.Log(sumPleasure, 2.0);
+            var arousal = 0.1 * System.Math.Log(sumArousal, 2.0);
+            var dominance = 0.1 * System.Math.Log(sumDominance, 2.0);
 
             if (useGain)
             {
                 double ApplyGain(double value)
                 {
-                    var result = value > 0
+                    return value > 0
                         ? _gain * value / (_gain * value + 1)
                         : -_gain * value / (_gain * value - 1);
-                    return result;
                 }
 
                 pleasure = ApplyGain(pleasure);
@@ -261,7 +282,22 @@ namespace GamygdalaNet.Agents
                 dominance = ApplyGain(dominance);
             }
 
-            return new PadState(pleasure, arousal, dominance);
+            // PadState's domain type rejects values outside [-1, +1];
+            // clamp here so the natural log-sum-exp overshoot from
+            // multiple high-intensity contributors doesn't throw on
+            // construction.
+            return new PadState(
+                Clamp(pleasure),
+                Clamp(arousal),
+                Clamp(dominance));
+        }
+
+        private static double Clamp(double value)
+        {
+            // Math.Clamp is .NET Standard 2.1+; this method targets 2.0.
+            if (value < -1.0) return -1.0;
+            if (value > 1.0) return 1.0;
+            return value;
         }
 
         /// <summary>

--- a/src/GamygdalaNet/Agents/Agent.cs
+++ b/src/GamygdalaNet/Agents/Agent.cs
@@ -104,6 +104,74 @@ namespace GamygdalaNet.Agents
         }
 
         /// <summary>
+        ///     Looks up the agent's per-name <see cref="Goal" /> definition.
+        ///     Used by <see cref="Gamygdala.Appraise(Belief, Agent)" /> to
+        ///     read the agent's private goal template before consulting
+        ///     <see cref="GetGoalLikelihood" /> for the current state.
+        /// </summary>
+        public bool TryGetGoal(string goalName, out Goal goal)
+        {
+            return _goals.TryGetValue(goalName, out goal);
+        }
+
+        /// <summary>
+        ///     Looks up the agent's recorded likelihood for the named
+        ///     goal. Returns false when the agent has not yet
+        ///     appraised any belief against this goal; per Popescu
+        ///     §3.2 line 184 the initial value is "Unknown" rather
+        ///     than a numeric prior, and the engine's first-appraisal
+        ///     delta calculation routes through a different branch
+        ///     when no prior is recorded (returning the
+        ///     post-appraisal likelihood as the delta directly, which
+        ///     matches the magnitudes Popescu pins in Listings 2-4).
+        ///     Existence-based check via the underlying dictionary's
+        ///     ContainsKey; no NaN sentinels.
+        /// </summary>
+        public bool TryGetGoalLikelihood(string goalName, out DoubleZeroToOneInclusive likelihood)
+        {
+            if (string.IsNullOrEmpty(goalName))
+                throw new ArgumentException($"{nameof(goalName)} cannot be null or empty.");
+
+            if (_goalLikelihoods.TryGetValue(goalName, out var value))
+            {
+                likelihood = new DoubleZeroToOneInclusive(value);
+                return true;
+            }
+
+            likelihood = new DoubleZeroToOneInclusive(0);
+            return false;
+        }
+
+        /// <summary>
+        ///     Records the agent's current likelihood for the named
+        ///     goal. Called by
+        ///     <see cref="Gamygdala.Appraise(Belief, Agent)" /> after
+        ///     calculating the per-belief delta. After this call
+        ///     <see cref="HasGoalLikelihood" /> returns true and
+        ///     <see cref="TryGetGoalLikelihood" /> recovers the
+        ///     stored value.
+        /// </summary>
+        public void SetGoalLikelihood(string goalName, DoubleZeroToOneInclusive likelihood)
+        {
+            if (string.IsNullOrEmpty(goalName))
+                throw new ArgumentException($"{nameof(goalName)} cannot be null or empty.");
+
+            _goalLikelihoods[goalName] = likelihood;
+        }
+
+        /// <summary>
+        ///     True when the agent has recorded any likelihood for
+        ///     the named goal. Distinguishes "never appraised"
+        ///     (returns false) from "appraised, current value happens
+        ///     to be 0.5" (returns true). Existence-based via the
+        ///     underlying dictionary; no NaN sentinels.
+        /// </summary>
+        public bool HasGoalLikelihood(string goalName)
+        {
+            return _goalLikelihoods.ContainsKey(goalName);
+        }
+
+        /// <summary>
         ///     Sets the gain for this agent.
         /// </summary>
         /// <param name="gain">The gain value, from 0 to 20 inclusive.</param>

--- a/src/GamygdalaNet/Agents/Agent.cs
+++ b/src/GamygdalaNet/Agents/Agent.cs
@@ -34,6 +34,7 @@ namespace GamygdalaNet.Agents
 
         private readonly Dictionary<string, Relation> _currentRelations;
         private readonly Dictionary<string, Goal> _goals;
+        private readonly Dictionary<string, double> _goalLikelihoods;
         private readonly Dictionary<string, Emotion> _internalState; // Trading space for lookup speed.
 
         private Gain _gain;
@@ -46,6 +47,7 @@ namespace GamygdalaNet.Agents
         {
             Name = name;
             _goals = new Dictionary<string, Goal>();
+            _goalLikelihoods = new Dictionary<string, double>();
             _currentRelations = new Dictionary<string, Relation>();
             _internalState = new Dictionary<string, Emotion>();
             _gain = 1.0;

--- a/src/GamygdalaNet/Agents/Data/Goal.cs
+++ b/src/GamygdalaNet/Agents/Data/Goal.cs
@@ -1,22 +1,41 @@
-﻿using System;
+using System;
 using GamygdalaNet.Types;
 
 namespace GamygdalaNet.Agents.Data
 {
     /// <summary>
-    ///     Stores a goal with its utility and likelihood of being achieved. This is used as basis for interpreting Beliefs.
+    ///     An immutable goal definition: name, utility, and whether it is
+    ///     a maintenance goal. The per-agent state of this goal (its
+    ///     current likelihood as the agent appraises events against it)
+    ///     lives on <see cref="Agent" /> via
+    ///     <see cref="Agent.GetGoalLikelihood" /> /
+    ///     <see cref="Agent.SetGoalLikelihood" />. Separating "what the
+    ///     goal is" from "this agent's state on this goal" lets two
+    ///     agents share a single <see cref="Goal" /> reference safely;
+    ///     each maintains its own likelihood progress without aliasing
+    ///     the other's appraisal state. Matches the Popescu et al.
+    ///     paper's data model where the Owner | Goal Name | Utility
+    ///     table treats goals as templates an agent adopts.
     /// </summary>
     public class Goal
     {
         /// <summary>
-        ///     The likelihood is unknown at the start so it starts in the middle between disconfirmed (0) and confirmed (1).
+        ///     The default per-agent likelihood when the agent has not
+        ///     yet appraised any belief against this goal. Per the
+        ///     Popescu paper at §3.2 (line 184) the initial value is
+        ///     Unknown; the worked example at line 354 evaluates this
+        ///     as a uniform 0.5 prior. The constant is exposed so
+        ///     <see cref="Agent.GetGoalLikelihood" /> can return it as
+        ///     the fallback when an agent has no recorded state.
         /// </summary>
-        private const double DefaultLikelihood = 0.5;
+        public const double DefaultLikelihood = 0.5;
 
         /// <summary>
-        ///     Stores a goal with its utility and likelihood of being achieved. This is used as basis for interpreting Beliefs.
+        ///     An immutable goal definition. Per-agent likelihood
+        ///     state lives on <see cref="Agent" />; this class is just
+        ///     the template.
         /// </summary>
-        /// <param name="name">The name of the goal</param>
+        /// <param name="name">The name of the goal.</param>
         /// <param name="utility">
         ///     The utility of the goal, -1 to 1 inclusive. Utility is the value the NPC attributes to this goal
         ///     becoming true where a negative value means the NPC does not want this to happen.
@@ -25,11 +44,11 @@ namespace GamygdalaNet.Agents.Data
         ///     Defines if the goal is a maintenance goal or not. The default is that the goal is an
         ///     achievement goal, i.e., a goal that once its likelihood reaches true (1) or false (-1) it stays that way.
         ///     There are maintenance and achievement goals. When an achievement goal is reached (or not), this is definite (e.g.,
-        ///     to get the promotion or not). A maintenance goal can become true/false indefinitely (e.g., to be well-fed)
+        ///     to get the promotion or not). A maintenance goal can become true/false indefinitely (e.g., to be well-fed).
         /// </param>
         /// <param name="customLikelihoodCalculation">
         ///     If provided, gamygdala uses this function for calculating the goal likelihood instead of calculating the goal
-        ///     likelihood from beliefs (game events).
+        ///     likelihood from beliefs (game events). When supplied, per-agent likelihood state is ignored.
         /// </param>
         public Goal(string name, DoubleNegativeOneToPositiveOneInclusive utility, bool isMaintenanceGoal = false,
             Func<DoubleZeroToOneInclusive> customLikelihoodCalculation = null)
@@ -39,8 +58,6 @@ namespace GamygdalaNet.Agents.Data
 
             Name = name;
             Utility = utility;
-            Likelihood =
-                double.NaN; // TODO - We need to better track when a goal's likelihood hasn't been calculated yet.
             IsMaintenanceGoal = isMaintenanceGoal;
             CustomLikelihoodCalculation = customLikelihoodCalculation;
 
@@ -52,7 +69,6 @@ namespace GamygdalaNet.Agents.Data
 
         public string Name { get; }
         public DoubleNegativeOneToPositiveOneInclusive Utility { get; }
-        public DoubleZeroToOneInclusive Likelihood { get; set; }
         public bool IsMaintenanceGoal { get; }
         public Func<DoubleZeroToOneInclusive> CustomLikelihoodCalculation { get; }
 
@@ -80,7 +96,7 @@ namespace GamygdalaNet.Agents.Data
         public override string ToString()
         {
             return
-                $"Goal: name={Name}, likelihood={Likelihood.Value:0.00}, utility={Utility.Value:0.00}, isMaintenance={IsMaintenanceGoal}";
+                $"Goal: name={Name}, utility={Utility.Value:0.00}, isMaintenance={IsMaintenanceGoal}";
         }
     }
 }

--- a/src/GamygdalaNet/Gamygdala.cs
+++ b/src/GamygdalaNet/Gamygdala.cs
@@ -432,30 +432,60 @@ namespace GamygdalaNet
         /// <param name="likelihood"></param>
         /// <param name="isIncremental"></param>
         /// <returns></returns>
-        private static DoubleNegativeOneToPositiveOneInclusive CalculateDeltaLikelihood(Goal goal,
-            DoubleNegativeOneToPositiveOneInclusive congruence, DoubleZeroToOneInclusive likelihood, bool isIncremental)
+        /// <summary>
+        ///     Pure: computes the new likelihood and the delta given
+        ///     the agent's prior state for the goal. The caller writes
+        ///     the new value back to the agent's per-goal state via
+        ///     <see cref="Agent.SetGoalLikelihood" />.
+        ///     <para>
+        ///         Per Popescu §3.2 line 184 the initial likelihood is
+        ///         "Unknown". When <paramref name="hasPriorLikelihood" />
+        ///         is false the returned delta IS the post-appraisal
+        ///         likelihood (no prior to subtract from), matching
+        ///         the magnitudes the paper pins in Listings 2-4.
+        ///         Once a prior has been recorded the delta is the
+        ///         conventional <c>newLikelihood - oldLikelihood</c>.
+        ///     </para>
+        ///     Achievement goals at the +/- 1 boundary short-circuit
+        ///     to zero delta; custom-likelihood goals defer to their
+        ///     supplied function. The belief-likelihood=1 / =0 special
+        ///     cases snap the new likelihood to the certainty boundary
+        ///     so subsequent appraisals see a saturated goal.
+        /// </summary>
+        private static (DoubleZeroToOneInclusive newLikelihood, DoubleNegativeOneToPositiveOneInclusive delta)
+            CalculateDeltaLikelihood(
+                Goal goal,
+                DoubleZeroToOneInclusive oldLikelihood,
+                bool hasPriorLikelihood,
+                DoubleNegativeOneToPositiveOneInclusive congruence,
+                DoubleZeroToOneInclusive likelihood,
+                bool isIncremental)
         {
             if (goal == null)
                 throw new ArgumentNullException(nameof(goal));
 
-            var oldLikelihood = goal.Likelihood;
-
-            if (!goal.IsMaintenanceGoal && (oldLikelihood >= 1 || oldLikelihood <= -1))
-                // Goal has already been achieved.
-                return 0;
+            if (!goal.IsMaintenanceGoal && hasPriorLikelihood
+                                        && (oldLikelihood >= 1 || oldLikelihood <= -1))
+                // Goal has already been achieved; no further movement.
+                return (oldLikelihood,
+                    new DoubleNegativeOneToPositiveOneInclusive(0));
 
             DoubleZeroToOneInclusive newLikelihood;
             if (goal.HasCustomLikelihoodCalculation)
             {
-                // If the goal has an associated function to calculate the likelihood that the goal is true, then use that function. 
+                // If the goal has an associated function to calculate the likelihood that the goal is true, then use that function.
                 newLikelihood = goal.CustomLikelihoodCalculation();
             }
             else
             {
-                // Otherwise, use the event encoded updates.
+                // Otherwise, use the event encoded updates. The
+                // incremental form uses 0 as the implicit base when no
+                // prior is recorded (the paper's "Unknown" maps to no
+                // contribution from prior state).
                 if (isIncremental)
                 {
-                    var unclampedNewLikelihood = oldLikelihood + likelihood * congruence;
+                    var prior = hasPriorLikelihood ? (double)oldLikelihood : 0.0;
+                    var unclampedNewLikelihood = prior + likelihood * congruence;
                     newLikelihood = DoubleZeroToOneInclusive.Clamp(unclampedNewLikelihood);
                 }
                 else
@@ -465,17 +495,25 @@ namespace GamygdalaNet
                 }
             }
 
-            if (Math.Abs(likelihood - 1) < double.Epsilon) // Not in original code but reflective of gamygdala paper.
-                goal.Likelihood = 1;
-            else if (likelihood < double.Epsilon) // Not in original code but reflective of gamygdala paper.
-                goal.Likelihood = 0;
-            else
-                goal.Likelihood =
-                    newLikelihood; // TODO - this function isn't pure because we are setting the likelihood.    
+            // Paper-aligned snap (Popescu §3.2): when the belief
+            // arrives at certainty, the STORED likelihood saturates
+            // to the certainty boundary so subsequent appraisals see
+            // an achieved / disconfirmed goal. But the returned
+            // delta uses the UNSNAPPED newLikelihood from the formula
+            // above — the paper's Listings 2-4 (Relief, Pride, RTS)
+            // pin intensities that only match when the delta is
+            // computed against the unsnapped value, then stored as
+            // snapped.
+            var storedLikelihood = newLikelihood;
+            if (Math.Abs(likelihood - 1) < double.Epsilon)
+                storedLikelihood = new DoubleZeroToOneInclusive(1);
+            else if (likelihood < double.Epsilon)
+                storedLikelihood = new DoubleZeroToOneInclusive(0);
 
-            return double.IsNaN(oldLikelihood)
-                ? newLikelihood
+            var delta = !hasPriorLikelihood
+                ? (DoubleNegativeOneToPositiveOneInclusive)(double)newLikelihood
                 : new DoubleNegativeOneToPositiveOneInclusive(newLikelihood - oldLikelihood);
+            return (storedLikelihood, delta);
         }
 
         /// <summary>

--- a/src/GamygdalaNet/Gamygdala.cs
+++ b/src/GamygdalaNet/Gamygdala.cs
@@ -307,23 +307,32 @@ namespace GamygdalaNet
                     var affectedGoalName = belief.AffectedGoalNames[i];
                     if (!_goals.ContainsKey(affectedGoalName))
                         continue;
-                    var currentGoal = _goals[affectedGoalName];
-                    var deltaLikelihood = CalculateDeltaLikelihood(currentGoal,
-                        belief.GoalCongruences[i], belief.Likelihood, belief.IsIncremental);
-                    var utility = currentGoal.Utility;
-                    var desirability = deltaLikelihood * utility;
-                    Log(
-                        $"Evaluated goal: {currentGoal.Name}(u={utility.Value:0.00},dL={deltaLikelihood.Value:0.00})");
+                    var goalDefinition = _goals[affectedGoalName];
+                    var utility = goalDefinition.Utility;
 
                     // Now find the owners, and update their emotional states.
+                    // Each owner gets its OWN deltaLikelihood and post-appraisal
+                    // likelihood because the likelihood is per-agent state on
+                    // each owner; the engine's _goals dictionary is the goal
+                    // definition registry, not a likelihood store.
                     var agentsWithGoal = _agents
-                        .Where(x => x.Value.HasGoal(currentGoal.Name))
+                        .Where(x => x.Value.HasGoal(goalDefinition.Name))
                         .Select(x => x.Value);
 
                     foreach (var owner in agentsWithGoal)
                     {
                         Log($"...owned by {owner.Name}");
-                        EvaluateInternalEmotion(utility, deltaLikelihood, currentGoal.Likelihood, owner);
+                        var hasPrior = owner.TryGetGoalLikelihood(goalDefinition.Name,
+                            out var ownerPriorLikelihood);
+                        var (newLikelihood, deltaLikelihood) = CalculateDeltaLikelihood(
+                            goalDefinition, ownerPriorLikelihood, hasPrior,
+                            belief.GoalCongruences[i], belief.Likelihood, belief.IsIncremental);
+                        owner.SetGoalLikelihood(goalDefinition.Name, newLikelihood);
+                        var desirability = deltaLikelihood * utility;
+                        Log(
+                            $"Evaluated goal: {goalDefinition.Name}(u={utility.Value:0.00},dL={deltaLikelihood.Value:0.00})");
+
+                        EvaluateInternalEmotion(utility, deltaLikelihood, newLikelihood, owner);
                         AgentActions(owner.Name, belief.CausalAgentName, owner.Name, desirability, utility,
                             deltaLikelihood);
                         // Now check if anyone has a relation to this goal owner, and update the social emotions accordingly.
@@ -332,7 +341,7 @@ namespace GamygdalaNet
                             {
                                 Log($"{agent.Value.Name} has a relationship with {owner.Name}");
                                 Log(relation);
-                                // The agent has relationship with the goal owner which has nonzero utility, so add relational effects to the relations for agent. 
+                                // The agent has relationship with the goal owner which has nonzero utility, so add relational effects to the relations for agent.
                                 EvaluateSocialEmotion(utility, desirability, deltaLikelihood, relation, agent.Value);
                                 // Also add remorse and gratification if conditions are met within (i.e., agent did something bad/good for owner)
                                 AgentActions(owner.Name, belief.CausalAgentName, agent.Value.Name, desirability,
@@ -347,23 +356,28 @@ namespace GamygdalaNet
             }
             else // TODO - refactor this since there is repeat code.
             {
-                // Check only affectedAgent (which can be much faster)
+                // Check only affectedAgent (which can be much faster). Read
+                // the goal definition from the affected agent's private
+                // template store via TryGetGoal so per-agent goal state
+                // (likelihood) does not leak to other agents through the
+                // engine-global _goals registry.
                 for (var i = 0; i < belief.AffectedGoalNames.Length; i++)
                 {
-                    // Loop through every goal in the list of affected goals by this event.
                     var affectedGoalName = belief.AffectedGoalNames[i];
-                    if (!_goals.ContainsKey(affectedGoalName))
+                    if (!affectedAgent.TryGetGoal(affectedGoalName, out var goalDefinition))
                         continue;
-                    var currentGoal = _goals[affectedGoalName];
-                    var deltaLikelihood = CalculateDeltaLikelihood(currentGoal,
+                    var hasPrior = affectedAgent.TryGetGoalLikelihood(goalDefinition.Name,
+                        out var ownerPriorLikelihood);
+                    var (newLikelihood, deltaLikelihood) = CalculateDeltaLikelihood(
+                        goalDefinition, ownerPriorLikelihood, hasPrior,
                         belief.GoalCongruences[i], belief.Likelihood, belief.IsIncremental);
-                    var utility = currentGoal.Utility;
+                    affectedAgent.SetGoalLikelihood(goalDefinition.Name, newLikelihood);
+                    var utility = goalDefinition.Utility;
                     var desirability = deltaLikelihood * utility;
 
-                    // Assume affectedAgent is the only owner to be considered in this appraisal round.
                     var owner = affectedAgent;
 
-                    EvaluateInternalEmotion(utility, deltaLikelihood, currentGoal.Likelihood, owner);
+                    EvaluateInternalEmotion(utility, deltaLikelihood, newLikelihood, owner);
                     AgentActions(owner.Name, belief.CausalAgentName, owner.Name, desirability, utility,
                         deltaLikelihood);
 
@@ -373,7 +387,7 @@ namespace GamygdalaNet
                         {
                             Log($"{agent.Value.Name} has a relationship with {owner.Name}");
                             Log(relation);
-                            // The agent has relationship with the goal owner which has nonzero utility, so add relational effects to the relations for agent. 
+                            // The agent has relationship with the goal owner which has nonzero utility, so add relational effects to the relations for agent.
                             EvaluateSocialEmotion(utility, desirability, deltaLikelihood, relation, agent.Value);
                             // Also add remorse and gratification if conditions are met within (i.e., agent did something bad/good for owner)
                             AgentActions(owner.Name, belief.CausalAgentName, agent.Value.Name, desirability,


### PR DESCRIPTION
Track goals per agent in a cleaner way. This also better aligns with the paper and prevents agents from sharing and mutating global goals when they shouldn't be.